### PR TITLE
[Bug Fix] Fixes ctr_name missing bug

### DIFF
--- a/src/r2egym/agenthub/runtime/docker.py
+++ b/src/r2egym/agenthub/runtime/docker.py
@@ -576,7 +576,7 @@ class DockerRuntime(ExecutionEnvironment):
 
     def reset(self):
         self.stop_container()
-        self.start_container(self.docker_image, self.command, **self.docker_kwargs)
+        self.start_container(self.docker_image, self.command, self.container_name, **self.docker_kwargs)
 
     def close(self):
         self.stop_container()


### PR DESCRIPTION
```python
self = <r2egym.agenthub.runtime.docker.DockerRuntime object at 0x7fec159c9210>

    def reset(self):
        self.stop_container()
>       self.start_container(self.docker_image, self.command, **self.docker_kwargs)
E       TypeError: DockerRuntime.start_container() missing 1 required positional argument: 'ctr_name'

../R2E-Gym/src/r2egym/agenthub/runtime/docker.py:579: TypeError
```

This fix addresses this issue.