### PR TITLE
fix(k8s): use per-instance client Configuration to avoid concurrency 401s & pod leaks

### DIFF
--- a/src/r2egym/agenthub/runtime/docker.py
+++ b/src/r2egym/agenthub/runtime/docker.py
@@ -145,12 +145,19 @@ class DockerRuntime(ExecutionEnvironment):
         if self.backend == "docker":
             self.client = docker.from_env(timeout=120)
         elif self.backend == "kubernetes":
-            # Try in-cluster config first, fallback to kubeconfig
+            # Try in-cluster config first, fallback to kubeconfig.
+            # Use a per-instance Configuration (not the process-global default) so that
+            # concurrent DockerRuntime instances do not race on shared client config.
+            # With many threads each calling load_incluster_config()/CoreV1Api(), the
+            # global default Configuration gets rebuilt mid-flight, intermittently
+            # emitting requests with a missing auth header -> 401 UnauthorizedException;
+            # when the racing call is delete_namespaced_pod the sandbox pod is orphaned.
+            k8s_config = client.Configuration()
             try:
-                config.load_incluster_config()
+                config.load_incluster_config(client_configuration=k8s_config)
             except Exception:
-                config.load_kube_config()
-            self.client = client.CoreV1Api()
+                config.load_kube_config(client_configuration=k8s_config)
+            self.client = client.CoreV1Api(client.ApiClient(k8s_config))
 
         # Start the container
         self.container = None


### PR DESCRIPTION
The kubernetes backend builds its client from the **process-global default Configuration**:

```python
config.load_incluster_config()
self.client = client.CoreV1Api()
```

When many `DockerRuntime` instances are created concurrently (a thread pool running agents in parallel), each `load_incluster_config()` rebuilds the shared global `Configuration` while other threads' API requests are in flight. Some requests then go out without a valid auth header and the API server rejects them with **HTTP 401** (`UnauthorizedException`).

Impact:
- When the racing call is `delete_namespaced_pod` (via `env.close()` → `_stop_kubernetes_pod`), the sandbox pod is **never deleted and leaks**. Over a long run leaked pods accumulate and pressure node pod/IP limits.
- Failed creates surface as spurious env-startup errors.

**Fix:** construct a per-instance `client.Configuration` and pass it explicitly to `load_incluster_config()`/`load_kube_config()` and to `CoreV1Api(ApiClient(cfg))`, so each runtime gets an isolated, thread-safe client and never mutates shared global state.

Observed on a 16-way-concurrent run: delete-side 401s dropped from ~22/600 tasks to ~1/600, and leaked sandbox pods (which had climbed to 60+) stayed bounded at the concurrency level. Single-threaded behavior is unchanged.