### PR TITLE
Fix test leakage: r2e_tests is symlinked back into the repo after being hidden

### DIFF
--- a/src/r2egym/agenthub/runtime/docker.py
+++ b/src/r2egym/agenthub/runtime/docker.py
@@ -4,6 +4,7 @@ from time import sleep
 import time
 import uuid
 import tempfile
+from contextlib import contextmanager
 import docker
 from docker.models.containers import Container
 
@@ -583,9 +584,11 @@ class DockerRuntime(ExecutionEnvironment):
             # r2e_tests are in the / directory, move them to /root
             self.run(f"mv /r2e_tests {self.alt_path}/r2e_tests")
 
-            # make a softlink for /root/r2e_tests (if present)
-            self.run(f"ln -s {self.alt_path}/r2e_tests {self.repo_path}/r2e_tests")
-            # self.run(f"ln -s /r2e_tests {self.repo_path}/r2e_tests")
+            # NOTE: deliberately no symlink back into the repo here. run_tests.sh
+            # needs the tests reachable from the repo root, but a link that lives
+            # for the whole rollout cancels out the `mv` above and leaves the
+            # held-out tests readable by the agent. `_r2e_tests_linked` creates it
+            # only for the duration of a test run instead.
         except Exception as e:
             self.logger.error(f"Error setting up environment: {repr(e)}")
 
@@ -848,16 +851,52 @@ class DockerRuntime(ExecutionEnvironment):
         output, _ = self.run(f"cat /{self.alt_path}/{rel_file_path}")
         return output
 
+    @contextmanager
+    def _r2e_tests_linked(self):
+        """Link the held-out tests into the repo for the duration of a test run.
+
+        The generated run_tests.sh refers to the tests by a repo-relative path
+        (`pytest -rA r2e_tests`, see repo_analysis_args.get_test_command), and
+        r2e_tests is an importable package, so it has to be reachable from the
+        repo root while the tests execute. It must NOT be reachable outside of
+        that window: r2e_tests is listed in SKIP_FILES_NEW so that the agent
+        cannot read the tests it is graded on.
+        """
+        if self.swebench_verified or self.swesmith:
+            # these images ship their own /run_tests.sh and have no /root/r2e_tests
+            yield
+            return
+
+        link_path = f"{self.repo_path}/r2e_tests"
+        # rm first: `ln -s` into an existing directory silently nests the link
+        # inside it, and the test run would then collect no tests at all.
+        # The /r2e_tests branch covers a container that was reset() after
+        # setup_env, where the tests are back at their image location.
+        self.run(
+            f"rm -rf {link_path} && "
+            f"if [ -d {self.alt_path}/r2e_tests ]; then "
+            f"ln -s {self.alt_path}/r2e_tests {link_path}; "
+            f"elif [ -d /r2e_tests ]; then ln -s /r2e_tests {link_path}; fi"
+        )
+        try:
+            yield
+        finally:
+            self.run(f"rm -rf {link_path}")
+
     def run_tests(self, timeout: int = 300) -> tuple[str, str]:
-        output, error_code = self.run(f"bash {self.alt_path}/run_tests.sh", timeout=timeout)
+        with self._r2e_tests_linked():
+            output, error_code = self.run(
+                f"bash {self.alt_path}/run_tests.sh", timeout=timeout
+            )
         # Remove ANSI escape codes and \r characters
         output = re.sub(r"\x1b\[[0-9;]*m|\r", "", output)
         return output, error_code
 
     def demux_run_tests(self) -> tuple[str, str, str]:
-        stdout, stderr, error_code = self.demux_run(
-            f"bash {self.alt_path}/run_tests.sh"
-        )
+        with self._r2e_tests_linked():
+            stdout, stderr, error_code = self.demux_run(
+                f"bash {self.alt_path}/run_tests.sh"
+            )
         # Remove ANSI escape codes and \r characters
         stdout = re.sub(r"\x1b\[[0-9;]*m|\r", "", stdout)
         stderr = re.sub(r"\x1b\[[0-9;]*m|\r", "", stderr)


### PR DESCRIPTION
## Problem

`SKIP_FILES_NEW` exists to keep two things away from the agent (`src/r2egym/agenthub/__init__.py:20-35`):

```python
# hidden / excluded files: to be hidden from the agent
SKIP_FILES_NEW = [
    "run_tests.sh",
    "r2e_tests",
]
```

`setup_env` honours that for both, and then immediately undoes it for one of them
(`src/r2egym/agenthub/runtime/docker.py:580-587`):

```python
for skip_file in SKIP_FILES_NEW:
    self.run(f"mv {self.repo_path}/{skip_file} {self.alt_path}/{skip_file}")

self.run(f"mv /r2e_tests {self.alt_path}/r2e_tests")
self.run(f"ln -s {self.alt_path}/r2e_tests {self.repo_path}/r2e_tests")   # <-- back inside the repo
```

For the whole rollout, `/testbed/r2e_tests` therefore resolves to the held-out tests, and
`_calculate_reward_r2e` grades on exactly those files. The agent's tools reach them without
doing anything unusual: `execute_bash` only blocks the leading tokens `git`, `ipython`,
`jupyter`, `nohup`, and `file_editor` / `search` accept arbitrary paths. `run_tests.sh` stays
hidden as intended; only `r2e_tests` is affected.

The exposure is opportunistic rather than automatic, which is probably why it went unnoticed:
`search.py` walks with `os.walk(directory)` and so does not follow the symlink
(`src/r2egym/agenthub/tools/search.py:36`). The realistic path is an agent that lists the repo
root, notices `r2e_tests/`, and reads it directly.

## Why the link is there

It is genuinely needed — just not for the whole episode. The generated test command is
repo-relative, and `r2e_tests` is an importable package:

- `src/r2egym/repo_analysis/repo_analysis_args.py:93` — `... -m pytest -rA r2e_tests`
- `src/r2egym/repo_analysis/repo_testextract.py:32` — writes `r2e_tests/__init__.py`

and `DockerRuntime.run` executes with `workdir=self.repo_path`, so the tests must be reachable
from the repo root *while they run*.

## Fix

Create the link in a context manager around the test run, and drop it afterwards.

Both methods that execute `run_tests.sh` are wrapped, which covers all four call sites
(`_calculate_reward_r2e`, plus three in `src/r2egym/repo_analysis/validate_docker_and_hf.py`)
with no changes needed at those sites.

The `swebench_verified` and `swesmith` paths are untouched — those images ship their own
`/run_tests.sh` and call `self.run` directly, and have no `/root/r2e_tests`.

Two details inside the context manager:

- `rm -rf` before `ln -s`: linking onto a directory that already exists at that path silently
  nests the link inside it, and the run would then collect no tests and score 0.
- the `elif [ -d /r2e_tests ]` branch covers a container that was `reset()` after `setup_env`,
  where the tests are back at their image location.

Side effect: `get_patch()` (`git add -A && git diff --cached`) no longer stages the symlink into
the extracted patch.